### PR TITLE
Fixed the username matching non-letters for the first character issue:

### DIFF
--- a/Course3/Lab4/validations.py
+++ b/Course3/Lab4/validations.py
@@ -13,7 +13,7 @@ def validate_user(username, minlen):
     if len(username) < minlen:
         return False
     # Usernames can only use letters, numbers, dots and underscores
-    if not re.match('^[a-z0-9._]*$', username):
+    if not re.match('^[a-zA-Z][a-z0-9._]*$', username):
         return False
     # Usernames can't begin with a number
     if username[0].isnumeric():
@@ -21,4 +21,8 @@ def validate_user(username, minlen):
     return True
 
 
+print(validate_user("blue.kale", 3)) # True
+print(validate_user(".blue.kale", 3)) # Currently True, should be False
+print(validate_user("red_quinoa", 4)) # True
+print(validate_user("_red_quinoa", 4)) # Currently True, should be False
 


### PR DESCRIPTION
Just put an extra [a-zA-Z] inbetween the existing ^ and [a-zA-Z] to get it to
match only letters for the first character.

Closes: #1

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR