### PR TITLE
closes #15488 Not allowing special character at the start of username

### DIFF
--- a/Course3/Lab4/validations.py
+++ b/Course3/Lab4/validations.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import re
 
 def validate_user(username, minlen):
@@ -15,10 +13,7 @@ def validate_user(username, minlen):
     # Usernames can only use letters, numbers, dots and underscores
     if not re.match('^[a-z0-9._]*$', username):
         return False
-    # Usernames can't begin with a number
-    if username[0].isnumeric():
+    # Usernames have to begin with an alphabet
+    if not username[0].isalpha():
         return False
     return True
-
-
-


### PR DESCRIPTION
Fixes #15488

Making sure that the first character is an alphabet prohibits both numbers and special characters ("." , "_") from being the first character of a username
